### PR TITLE
use older gcc-7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,17 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Set up GCC
+        uses: egor-tensin/setup-gcc@v1
+        with:
+          version: 7
+          platform: x64
 
       - name: Set up MinGW
         uses: egor-tensin/setup-mingw@v2
@@ -28,7 +34,7 @@ jobs:
 
       - name: Build
         run: |
-          make dummyengine
+          make dummyengine CXX_COMPILER=g++-7
           make dummyengine.exe
 
       - name: Upload Artifact

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 APPNAME := dummyengine
+CXX_COMPILER := g++
+MINGW_CXX_COMPILER = i686-w64-mingw32-g++
 
 .PHONY: clean
 
@@ -6,8 +8,8 @@ clean:
 	@rm -f $(APPNAME) $(APPNAME).exe
 
 $(APPNAME): src/main.cpp
-	g++ -o $@ src/main.cpp -static-libgcc -Wl,-Bstatic -lstdc++ -lm -Wl,-Bdynamic -Wl,--as-needed
+	$(CXX_COMPILER) -o $@ src/main.cpp -static-libgcc -Wl,-Bstatic -lstdc++ -lm -Wl,-Bdynamic -Wl,--as-needed
 	strip $@
 
 $(APPNAME).exe: src/main.cpp
-	i686-w64-mingw32-c++ -o $@ src/main.cpp -static-libgcc -Wl,-Bstatic -lstdc++ -lwinpthread -Wl,-Bdynamic -Wl,--as-needed
+	$(MINGW_CXX_COMPILER) -o $@ src/main.cpp -static-libgcc -Wl,-Bstatic -lstdc++ -lwinpthread -Wl,-Bdynamic -Wl,--as-needed


### PR DESCRIPTION
`glibc` too new for stable `debian`:
```
root@debian:~# ./dummyengine
./dummyengine: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by ./dummyengine)
./dummyengine: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./dummyengine)
```
So downgrade `g++` to 7. Should be compatible with `buster` (old stable) and even `alpine` with `gcompat`.